### PR TITLE
Migrate mcp server from streamable-http to stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,31 @@ See the [full documentation](docs/README.md).
 
 ## Using our MCP Server
 
-1. Export any environment variables you would need to, like database credentials or your API keys. More in [README_MCP.md](./README_MCP.md)
-2. Run `defog serve`
-3. Add to your MCP Client
+1. Run `defog serve` once to complete your setup, and `defog db` to update your database credentials
+2. Add to your MCP Client
+    - Claude Code: `claude mcp add defog -- defog serve`
+    - Claude Desktop: add the config below
+    ```json
+    {
+        "mcpServers": {
+            "defog": {
+                "command": "python3",
+                "args": ["-m", "defog.mcp_server"],
+                "env": {
+                    "OPENAI_API_KEY": "YOUR_OPENAI_KEY",
+                    "ANTHROPIC_API_KEY": "YOUR_ANTHROPIC_KEY",
+                    "GEMINI_API_KEY": "YOUR_GEMINI_KEY",
+                    "DB_TYPE": "YOUR_DB_TYPE",
+                    "DB_HOST": "YOUR_DB_HOST",
+                    "DB_PORT": "YOUR_DB_PORT",
+                    "DB_USER": "YOUR_DB_USER",
+                    "DB_PASSWORD": "YOUR_DB_PASSWORD",
+                    "DB_NAME": "YOUR_DB_NAME"
+                }
+            }
+        }
+        }
+    ```
 
 ## License
 

--- a/README_MCP.md
+++ b/README_MCP.md
@@ -150,6 +150,8 @@ The CLI wizard will automatically launch if required environment variables are m
       "args": ["serve"],
       "env": {
         "OPENAI_API_KEY": "your-openai-key",
+        "ANTHROPIC_API_KEY": "your-anthropic-key",
+        "GEMINI_API_KEY": "your-gemini-key",
         "DB_TYPE": "postgres",
         "DB_HOST": "localhost",
         "DB_PORT": "5432",

--- a/defog/mcp_server.py
+++ b/defog/mcp_server.py
@@ -277,7 +277,11 @@ def run_server():
     except Exception as e:
         logger.warning(f"Could not list tools: {e}")
 
-    mcp.run(transport="streamable-http", port=33364)
+    # disable streamable-http for now, until Claude Desktop supports it
+    # mcp.run(transport="streamable-http", port=33364)
+
+    # use normal HTTP (stdio under the hood, AFAIK) for now
+    mcp.run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Claude Desktop only seems to support `stdio` based local MCPs for now, so the MCP server has been moved to an stdio based one instead of a `streamable-http` based one.

With this, it works quite well with Claude Desktop!

![image](https://github.com/user-attachments/assets/3135545c-46a5-4664-8353-1b09279d183a)

![image](https://github.com/user-attachments/assets/0718c268-5244-4f33-81cf-63a44c5b317f)
