### PR TITLE
Add HTML and text data extraction tools to MCP server

### DIFF
--- a/README_MCP.md
+++ b/README_MCP.md
@@ -1,15 +1,16 @@
 # Defog MCP Server
 
-The Model Context Protocol (MCP) server for Defog Python provides tools for SQL queries, code interpretation, web search, YouTube transcription, and PDF data extraction.
+The Model Context Protocol (MCP) server for Defog Python provides tools for SQL queries, code interpretation, web search, YouTube transcription, PDF data extraction, and structured data extraction from HTML and text.
 
 ## Overview
 
 This MCP server exposes the following tools:
-- **run_query**: Execute natural language queries against SQL databases
-- **code_interpreter**: Execute Python code for data analysis and calculations
-- **web_search**: Search the web for information with citations
+- **text_to_sql_tool**: Execute natural language queries against SQL databases
+- **list_database_schema**: List all tables and their schemas in the configured database
 - **youtube_video_summary**: Get transcripts/summaries of YouTube videos
 - **extract_pdf_data**: Extract structured data from PDF documents
+- **extract_html_data**: Extract structured data from HTML content (tables, lists, key-value pairs)
+- **extract_text_data**: Extract structured data from plain text (Q&A pairs, tables, lists, metrics)
 
 ## Setup
 

--- a/defog/llm/text_data_extractor.py
+++ b/defog/llm/text_data_extractor.py
@@ -150,7 +150,6 @@ class TextDataExtractor:
 Find all structured data patterns:
 - Key-value pairs (metrics, statistics, dates)
 - Numerical data (percentages, amounts, rates)
-- Time-based data (dates, timelines, sequences)
 
 ONLY focus on numerically focused data. Do not focus on general qualitative statements, general questions and answers, or other non-numerical data.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {
 setup(
     name="defog",
     packages=find_packages(),
-    version="1.1.9",
+    version="1.1.10",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
## Summary
- Added `extract_html_data` tool to extract structured data from HTML content (tables, lists, key-value pairs)
- Added `extract_text_data` tool to extract structured data from plain text files (Q&A pairs, tables, lists, metrics)
- Both tools support multiple LLM providers (OpenAI with o3, Anthropic with Claude 4 Sonnet, Gemini with Pro 2.5)
- Updated MCP documentation to include the new extraction tools
- Minor prompt refinement in text data extractor to focus on numerical data

## Test plan
- [x] Test HTML data extraction from various web pages
- [x] Test text data extraction from plain text files
- [x] Verify tool registration in MCP server
- [x] Test with different LLM providers (OpenAI, Anthropic, Gemini)
- [x] Verify error handling for invalid URLs and missing files