### PR TITLE
Fix MCP server config loading and add transport/port options

### DIFF
--- a/defog/mcp_server.py
+++ b/defog/mcp_server.py
@@ -570,10 +570,10 @@ def run_server(transport=None, port=None):
     if transport == "streamable-http":
         if port:
             logger.info(f"Starting MCP server with streamable-http on port {port}")
-            mcp.run(transport="streamable-http", port=port)
+            mcp.run(transport="streamable-http", port=port, host="0.0.0.0")
         else:
             logger.info("Starting MCP server with streamable-http on default port")
-            mcp.run(transport="streamable-http")
+            mcp.run(transport="streamable-http", host="0.0.0.0")
     else:
         # Default to stdio
         logger.info("Starting MCP server with stdio transport")

--- a/defog/mcp_server.py
+++ b/defog/mcp_server.py
@@ -538,8 +538,13 @@ else:
     )
 
 
-def run_server():
-    """Run the MCP server."""
+def run_server(transport=None, port=None):
+    """Run the MCP server.
+
+    Args:
+        transport: Transport type (e.g., 'stdio', 'streamable-http')
+        port: Port number for streamable-http transport
+    """
     logger.info("Starting Defog Browser")
 
     # Log database validation status
@@ -561,12 +566,38 @@ def run_server():
     except Exception as e:
         logger.warning(f"Could not list tools: {e}")
 
-    # disable streamable-http for now, until Claude Desktop supports it
-    # mcp.run(transport="streamable-http", port=33364)
-
-    # use normal HTTP (stdio under the hood, AFAIK) for now
-    mcp.run()
+    # Run with specified transport and port, or defaults
+    if transport == "streamable-http":
+        if port:
+            logger.info(f"Starting MCP server with streamable-http on port {port}")
+            mcp.run(transport="streamable-http", port=port)
+        else:
+            logger.info("Starting MCP server with streamable-http on default port")
+            mcp.run(transport="streamable-http")
+    else:
+        # Default to stdio
+        logger.info("Starting MCP server with stdio transport")
+        mcp.run()
 
 
 if __name__ == "__main__":
-    run_server()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Defog MCP Server - Provides tools for SQL queries, code interpretation, and more"
+    )
+    parser.add_argument(
+        "--transport",
+        type=str,
+        default=None,
+        help="Transport type (e.g., 'stdio', 'streamable-http'). Default: stdio",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port number for streamable-http transport",
+    )
+
+    args = parser.parse_args()
+    run_server(transport=args.transport, port=args.port)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {
 setup(
     name="defog",
     packages=find_packages(),
-    version="1.1.11",
+    version="1.1.12",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {
 setup(
     name="defog",
     packages=find_packages(),
-    version="1.1.12",
+    version="1.1.13",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
## Summary
- Fixed issue where MCP server doesn't read the latest config file on first run
- Added optional `--transport` and `--port` arguments to customize MCP server transport

## Changes

### Config Loading Fix
The MCP server was validating database credentials at module import time, before the CLI wizard had a chance to update the config file. This caused the server to not see newly configured values on the first run.

**Solution:**
- Delayed the import of `mcp_server` module until after config is updated
- Added `config.reload()` call after environment variables are set
- This ensures the MCP server sees the latest configuration values

### Transport Options
Added support for customizing the MCP server transport:
- `--transport`: Specify transport type (e.g., 'stdio', 'streamable-http')
- `--port`: Specify port number when using streamable-http transport

These options are available for both:
- `defog serve --transport streamable-http --port 33364`
- `python -m defog.mcp_server --transport streamable-http --port 33364`

## Test plan
- [x] Tested config loading on first run
- [x] Verified transport options work correctly
- [x] Ran ruff linter and formatter