### PR TITLE
Add config file support to chat_async API key loading

### DIFF
--- a/defog/llm/config/settings.py
+++ b/defog/llm/config/settings.py
@@ -8,6 +8,7 @@ from .constants import (
     OPENAI_BASE_URL,
     ALIBABA_BASE_URL,
 )
+from defog import config
 
 
 class LLMConfig:
@@ -36,7 +37,7 @@ class LLMConfig:
         self._setup_base_urls()
 
     def _setup_api_keys(self):
-        """Setup API keys with environment variable fallbacks."""
+        """Setup API keys with environment variable and config file fallbacks."""
         key_mappings = {
             "openai": "OPENAI_API_KEY",
             "anthropic": "ANTHROPIC_API_KEY",
@@ -49,7 +50,8 @@ class LLMConfig:
 
         for provider, env_var in key_mappings.items():
             if provider not in self.api_keys:
-                self.api_keys[provider] = os.getenv(env_var)
+                # Try environment variable first, then fall back to config file
+                self.api_keys[provider] = os.getenv(env_var) or config.get(env_var)
 
     def _setup_base_urls(self):
         """Setup base URLs with defaults."""

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {
 setup(
     name="defog",
     packages=find_packages(),
-    version="1.1.13",
+    version="1.1.14",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
## Summary
- Adds support for reading API keys from the config file in `chat_async`
- Aligns behavior with the MCP server's text-to-sql tool

## Changes
- Updated `LLMConfig._setup_api_keys()` to fall back to config file when environment variables are not set
- Priority order: Environment variables (highest) → Config file (fallback)
- Config file is located at `~/.defog/config.json`

## Test plan
Tested locally by:
1. Verifying API keys are read from environment variables when set
2. Removing environment variables and confirming fallback to config file works
3. Running `ruff check` to ensure code style compliance