### PR TITLE
feat: add support for regular functions as tools in chat_async

### DIFF
--- a/docs/llm-utilities.md
+++ b/docs/llm-utilities.md
@@ -188,9 +188,46 @@ messages = [
 
 ## Function Calling
 
-Define tools for LLMs to call with automatic schema generation.
+Define tools for LLMs to call with automatic schema generation. As of version 0.50.0, you can use regular Python functions directly as tools!
 
 ### Basic Function Definition
+
+You can define tools in two ways:
+
+#### Option 1: Regular Functions (NEW - Simpler!)
+
+```python
+from defog.llm.utils import chat_async
+from typing import Optional
+
+# Regular function with type annotations
+def get_weather(location: str, units: str = "celsius") -> str:
+    """
+    Get current weather for a location.
+    
+    Args:
+        location: City and country
+        units: Temperature units (celsius or fahrenheit)
+    """
+    return f"Weather in {location}: 22°{units[0].upper()}, sunny"
+
+# Async functions are also supported
+async def search_web(query: str, max_results: Optional[int] = 5) -> list[str]:
+    """Search the web for information"""
+    # Implementation here
+    return [f"Result {i} for {query}" for i in range(max_results)]
+
+# Use directly as tools - no Pydantic needed!
+response = await chat_async(
+    provider=LLMProvider.OPENAI,
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[get_weather, search_web],
+    tool_choice="auto"
+)
+```
+
+#### Option 2: Pydantic-based Functions (Traditional)
 
 ```python
 from pydantic import BaseModel, Field
@@ -212,6 +249,20 @@ response = await chat_async(
     tool_choice="auto"
 )
 ```
+
+### When to Use Each Approach
+
+**Use Regular Functions when:**
+- You want simpler, more Pythonic code
+- Your function parameters are straightforward types
+- You're prototyping or building quickly
+- You prefer type hints over Pydantic models
+
+**Use Pydantic Functions when:**
+- You need complex validation logic
+- You want detailed field descriptions and constraints
+- You're working with nested data structures
+- You need custom validators or serializers
 
 ### Advanced Tool Configuration
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {
 setup(
     name="defog",
     packages=find_packages(),
-    version="1.1.14",
+    version="1.1.15",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
## Summary
- Added support for using regular Python functions directly as tools in `chat_async`
- No longer requires wrapping every function in a Pydantic model for simple use cases
- Maintains full backward compatibility with existing Pydantic-based tools

## Changes
- Added automatic detection of function style (regular vs Pydantic) in `utils_function_calling.py`
- Created wrapper utilities to convert regular function signatures to Pydantic models dynamically
- Updated `execute_tool` and `execute_tool_async` to handle both function styles
- Added comprehensive tests for the new functionality
- Updated documentation with examples showing both approaches

## Example Usage

### Before (required Pydantic model):
```python
class WeatherInput(BaseModel):
    location: str = Field(description="City and country")
    units: str = Field(default="celsius")

def get_weather(input: WeatherInput) -> str:
    return f"Weather in {input.location}: 22°{input.units[0].upper()}"

await chat_async(tools=[get_weather])
```

### After (simple function works):
```python
def get_weather(location: str, units: str = "celsius") -> str:
    """Get weather for a location"""
    return f"Weather in {location}: 22°{units[0].upper()}"

await chat_async(tools=[get_weather])  # Just works\!
```

## Benefits
- Simpler, more Pythonic API for basic use cases
- Easier prototyping and development
- Reduced boilerplate code
- Full backward compatibility

## Test plan
- [x] Run existing tests to ensure backward compatibility
- [x] Add unit tests for regular function wrapping
- [x] Add integration test with chat_async
- [x] Test with various function signatures (defaults, optional params, async)
- [x] Update documentation