### PR TITLE
Add HTTP transport support for MCP servers

### DIFF
--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -308,3 +308,6 @@ for name in dir(async_health_methods):
     if callable(attr):
         # Add the method to AsyncDefog
         setattr(AsyncDefog, name, attr)
+
+# Export LLMProvider for external use
+__all__ = ['Defog', 'AsyncDefog', 'LLMProvider']


### PR DESCRIPTION
- Add streamablehttp_client import for HTTP connections
- Implement _connect_to_mcp_http_server method
- Add HTTP transport detection in connect_to_server_from_config
- Support 'transport' parameter in MCP config for protocol selection
- Add recursive schema cleaning for Gemini compatibility which errors out if there are additional properties in a pydantic model (similar to function calling fixes in `utils_function_calling`)
- Export LLMProvider in __all__ for external usage

We leave the stdio and sse untouched.