### PR TITLE
Fix parallel tool calling across providers

### DIFF
--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -117,6 +117,7 @@ class AnthropicProvider(BaseLLMProvider):
         timeout: int = 600,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        parallel_tool_calls: bool = False,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """Create the parameter dict for Anthropic's .messages.create()."""
@@ -236,7 +237,7 @@ THE RESPONSE SHOULD START WITH '{{' AND END WITH '}}' WITH NO OTHER CHARACTERS B
 
             # Add parallel tool calls configuration
             if "tool_choice" in params and isinstance(params["tool_choice"], dict):
-                if not self.config.enable_parallel_tool_calls:
+                if not parallel_tool_calls:
                     params["tool_choice"]["disable_parallel_tool_use"] = True
 
         return params, messages
@@ -364,6 +365,9 @@ THE RESPONSE SHOULD START WITH '{{' AND END WITH '}}' WITH NO OTHER CHARACTERS B
                                 post_tool_function,
                                 consecutive_exceptions,
                                 tool_handler=tool_handler,
+                                parallel_tool_calls=kwargs.get(
+                                    "parallel_tool_calls", True
+                                ),
                             )
 
                         # For MCP tools, extract results from mcp_tool_result blocks
@@ -737,6 +741,7 @@ THE RESPONSE SHOULD START WITH '{{' AND END WITH '}}' WITH NO OTHER CHARACTERS B
             response_format=response_format,
             reasoning_effort=reasoning_effort,
             timeout=timeout,
+            parallel_tool_calls=kwargs.get("parallel_tool_calls", True),
         )
 
         # Construct a tool dict if needed
@@ -766,6 +771,7 @@ THE RESPONSE SHOULD START WITH '{{' AND END WITH '}}' WITH NO OTHER CHARACTERS B
                 post_tool_function=post_tool_function,
                 image_result_keys=image_result_keys,
                 tool_handler=tool_handler,
+                **kwargs,
             )
         except Exception as e:
             traceback.print_exc()

--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -57,6 +57,7 @@ class BaseLLMProvider(ABC):
         timeout: int = 600,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        parallel_tool_calls: bool = False,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """Build parameters for the provider's API call."""
@@ -218,6 +219,7 @@ class BaseLLMProvider(ABC):
         post_tool_function: Optional[Callable] = None,
         consecutive_exceptions: int = 0,
         tool_handler: Optional[ToolHandler] = None,
+        parallel_tool_calls: Optional[bool] = None,
     ) -> Tuple[List[Any], int]:
         """Common tool handling logic shared by all providers."""
         # Use provided tool_handler or fall back to self.tool_handler
@@ -227,10 +229,11 @@ class BaseLLMProvider(ABC):
         tool_outputs = []
 
         try:
+            # Use provided parallel_tool_calls or fall back to config
             tool_outputs = await tool_handler.execute_tool_calls_batch(
                 tool_calls,
                 tool_dict,
-                enable_parallel=self.config.enable_parallel_tool_calls,
+                parallel_tool_calls=parallel_tool_calls,
                 post_tool_function=post_tool_function,
             )
             consecutive_exceptions = 0

--- a/defog/llm/providers/gemini_provider.py
+++ b/defog/llm/providers/gemini_provider.py
@@ -138,6 +138,7 @@ class GeminiProvider(BaseLLMProvider):
         timeout: int = 600,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        parallel_tool_calls: bool = False,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """Construct parameters for Gemini's generate_content call."""

--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -158,6 +158,7 @@ class OpenAIProvider(BaseLLMProvider):
         timeout: int = 600,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        parallel_tool_calls: bool = False,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """
@@ -189,12 +190,8 @@ class OpenAIProvider(BaseLLMProvider):
             else:
                 request_params["tool_choice"] = "auto"
 
-            # Set parallel_tool_calls based on configuration
-            # this parameter is not available on the o-series models, though
-            if not model.startswith("o"):
-                request_params["parallel_tool_calls"] = (
-                    self.config.enable_parallel_tool_calls
-                )
+            # Set parallel_tool_calls based on parameter
+            request_params["parallel_tool_calls"] = parallel_tool_calls
 
         # Some models do not allow temperature or response_format:
         if model.startswith("o") or model == "deepseek-reasoner":
@@ -229,6 +226,7 @@ class OpenAIProvider(BaseLLMProvider):
         post_tool_function: Optional[Callable] = None,
         image_result_keys: Optional[List[str]] = None,
         tool_handler: Optional[ToolHandler] = None,
+        parallel_tool_calls: bool = False,
         **kwargs,
     ) -> Tuple[
         Any, List[Dict[str, Any]], int, int, Optional[int], Optional[Dict[str, int]]
@@ -291,6 +289,7 @@ class OpenAIProvider(BaseLLMProvider):
                             post_tool_function,
                             consecutive_exceptions,
                             tool_handler,
+                            parallel_tool_calls=parallel_tool_calls,
                         )
 
                         # Append the tool calls as an assistant response
@@ -479,6 +478,7 @@ class OpenAIProvider(BaseLLMProvider):
         post_tool_function: Optional[Callable] = None,
         image_result_keys: Optional[List[str]] = None,
         tool_budget: Optional[Dict[str, int]] = None,
+        parallel_tool_calls: bool = False,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with OpenAI."""
@@ -510,6 +510,7 @@ class OpenAIProvider(BaseLLMProvider):
             store=store,
             metadata=metadata,
             timeout=timeout,
+            parallel_tool_calls=parallel_tool_calls,
         )
 
         # Build a tool dict if needed
@@ -546,6 +547,7 @@ class OpenAIProvider(BaseLLMProvider):
                 post_tool_function=post_tool_function,
                 image_result_keys=image_result_keys,
                 tool_handler=tool_handler,
+                parallel_tool_calls=parallel_tool_calls,
             )
         except Exception as e:
             raise ProviderError(self.get_provider_name(), f"API call failed: {e}", e)

--- a/defog/llm/tools/handler.py
+++ b/defog/llm/tools/handler.py
@@ -148,7 +148,7 @@ class ToolHandler:
         self,
         tool_calls: List[Dict[str, Any]],
         tool_dict: Dict[str, Callable],
-        enable_parallel: bool = False,
+        parallel_tool_calls: bool = False,
         post_tool_function: Optional[Callable] = None,
     ) -> List[Any]:
         """Execute multiple tool calls either in parallel or sequentially."""
@@ -156,7 +156,7 @@ class ToolHandler:
 
         try:
             # Execute tools with budget tracking
-            if not enable_parallel:
+            if not parallel_tool_calls:
                 # Sequential execution with budget updates
                 results = []
                 for tool_call in tool_calls:
@@ -176,7 +176,7 @@ class ToolHandler:
             else:
                 # Parallel execution - execute tools then update budgets
                 results = await execute_tools_parallel(
-                    tool_calls, tool_dict, enable_parallel
+                    tool_calls, tool_dict, parallel_tool_calls
                 )
 
                 # Update budgets for successful executions

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -111,6 +111,7 @@ async def chat_async(
     image_result_keys: Optional[List[str]] = None,
     tool_budget: Optional[Dict[str, int]] = None,
     insert_tool_citations: bool = False,
+    parallel_tool_calls: bool = False,
 ) -> LLMResponse:
     """
     Execute a chat completion with explicit provider parameter.
@@ -139,6 +140,7 @@ async def chat_async(
         image_result_keys: List of keys to check in tool results for image data (e.g., ['image_base64', 'screenshot_data'])
         tool_budget: Dictionary mapping tool names to maximum allowed calls. Tools not in the dictionary have unlimited calls.
         insert_tool_citations: If True, adds citations to the response using tool outputs as source documents (OpenAI and Anthropic only)
+        parallel_tool_calls: Enable parallel tool calls when set to True (default: False)
 
     Returns:
         LLMResponse object containing the result
@@ -220,6 +222,7 @@ async def chat_async(
                 post_tool_function=post_tool_function,
                 image_result_keys=image_result_keys,
                 tool_budget=tool_budget,
+                parallel_tool_calls=parallel_tool_calls,
             )
 
             # Process citations if requested and provider supports it

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -417,7 +417,7 @@ async def execute_tool_async(tool: Callable, inputs: Dict[str, Any]):
 async def execute_tools_parallel(
     tool_calls: List[Dict[str, Any]],
     tool_dict: Dict[str, Callable],
-    enable_parallel: bool = False,
+    parallel_tool_calls: bool = False,
 ) -> List[Any]:
     """
     Execute multiple tool calls either in parallel or sequentially.
@@ -430,7 +430,7 @@ async def execute_tools_parallel(
     Returns:
         List of tool execution results in the same order as input tool_calls
     """
-    if not enable_parallel:
+    if not parallel_tool_calls:
         # Sequential execution (current behavior)
         results = []
         for tool_call in tool_calls:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -220,20 +220,30 @@ Main function for LLM interactions.
 
 ```python
 async def chat_async(
-    provider: Union[str, LLMProvider],
+    provider: Union[LLMProvider, str],
     model: str,
-    messages: List[dict],
+    messages: List[Dict[str, Any]],
     max_completion_tokens: Optional[int] = None,
     temperature: float = 0.0,
-    top_p: Optional[float] = None,
-    frequency_penalty: Optional[float] = None,
-    presence_penalty: Optional[float] = None,
-    response_format: Optional[Type[BaseModel]] = None,
+    response_format=None,
+    seed: int = 0,
+    store: bool = True,
+    metadata: Optional[Dict[str, str]] = None,
+    timeout: int = 600,
+    backup_model: Optional[str] = None,
+    backup_provider: Optional[Union[LLMProvider, str]] = None,
+    prediction: Optional[Dict[str, str]] = None,
+    reasoning_effort: Optional[str] = None,
     tools: Optional[List[Callable]] = None,
     tool_choice: Optional[str] = None,
-    reasoning_effort: Optional[str] = None,  # For o1 models
-    verbose: bool = False,
-    return_usage: bool = False
+    max_retries: Optional[int] = None,
+    post_tool_function: Optional[Callable] = None,
+    config: Optional[LLMConfig] = None,
+    mcp_servers: Optional[List[str]] = None,
+    image_result_keys: Optional[List[str]] = None,
+    tool_budget: Optional[Dict[str, int]] = None,
+    insert_tool_citations: bool = False,
+    parallel_tool_calls: bool = False,
 ) -> LLMResponse
 ```
 
@@ -244,14 +254,16 @@ Response object from LLM calls.
 ```python
 @dataclass
 class LLMResponse:
-    content: str
-    raw_response: dict
-    cost_in_cents: float
-    provider: str
+    content: Any
     model: str
-    usage: Optional[dict] = None
-    parsed: Optional[BaseModel] = None  # For structured outputs
-    tool_calls: Optional[List[dict]] = None
+    time: float
+    input_tokens: int
+    output_tokens: int
+    cached_input_tokens: Optional[int] = None
+    output_tokens_details: Optional[Dict[str, int]] = None
+    cost_in_cents: Optional[float] = None
+    tool_outputs: Optional[List[Dict[str, Any]]] = None
+    citations: Optional[List[Dict[str, Any]]] = None
 ```
 
 ### Tool Functions

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {
 setup(
     name="defog",
     packages=find_packages(),
-    version="1.2.1",
+    version="1.2.2",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
## Summary
- Fixed parallel tool calling implementation to be a runtime parameter instead of a config setting
- Updated all providers (OpenAI, Anthropic, Gemini) to accept `parallel_tool_calls` parameter
- Simplified tests by removing config-based testing in favor of parameter-based testing

## Changes
- Added `parallel_tool_calls` parameter to `chat_async()` function with default value of `False`
- Modified provider implementations to pass this parameter through the call chain
- Updated tool handler to use the parameter instead of config setting
- Refactored tests to use the new parameter approach
- Updated API reference documentation

## Test plan
- [x] Run existing tests with `python -m pytest tests/test_llm_tool_calls.py`
- [x] Verify parallel execution works correctly with `parallel_tool_calls=True`
- [x] Verify sequential execution works correctly with `parallel_tool_calls=False`
- [x] Test with multiple providers (OpenAI, Anthropic)