### PR TITLE
Add optional post_response_hook for openai, anthropic and gemini providers

### DIFF
--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -106,6 +106,7 @@ async def chat_async(
     tool_choice: Optional[str] = None,
     max_retries: Optional[int] = None,
     post_tool_function: Optional[Callable] = None,
+    post_response_hook: Optional[Callable] = None,
     config: Optional[LLMConfig] = None,
     mcp_servers: Optional[List[str]] = None,
     image_result_keys: Optional[List[str]] = None,
@@ -134,7 +135,8 @@ async def chat_async(
         tools: List of tools the model can call
         tool_choice: Tool calling behavior ("auto", "required", function name)
         max_retries: Maximum number of retry attempts
-        post_tool_function: Function to call after each tool execution
+        post_tool_function: Function to call after each tool execution. Must have parameters: function_name, input_args, tool_result
+        post_response_hook: Function to call after each response is received from the model. Must have parameters: response, messages
         config: LLM configuration object
         mcp_servers: List of MCP server urls for streamable http servers (e.g., ["http://localhost:8000/mcp", "http://localhost:8001/mcp"])
         image_result_keys: List of keys to check in tool results for image data (e.g., ['image_base64', 'screenshot_data'])
@@ -204,6 +206,10 @@ async def chat_async(
             # Get provider instance
             provider_instance = get_provider_instance(current_provider, config)
 
+            if post_response_hook:
+                provider_instance.validate_post_response_hook(post_response_hook)
+
+
             # Execute the chat completion
             response = await provider_instance.execute_chat(
                 messages=messages,
@@ -220,6 +226,7 @@ async def chat_async(
                 prediction=prediction,
                 reasoning_effort=reasoning_effort,
                 post_tool_function=post_tool_function,
+                post_response_hook=post_response_hook,
                 image_result_keys=image_result_keys,
                 tool_budget=tool_budget,
                 parallel_tool_calls=parallel_tool_calls,

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -505,3 +505,4 @@ def verify_post_tool_function(function: Callable):
         raise ValueError("post_tool_function must have parameter named `tool_result`")
 
     return function
+

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -417,7 +417,7 @@ async def execute_tool_async(tool: Callable, inputs: Dict[str, Any]):
 async def execute_tools_parallel(
     tool_calls: List[Dict[str, Any]],
     tool_dict: Dict[str, Callable],
-    parallel_tool_calls: bool = False,
+    enable_parallel: bool = False,
 ) -> List[Any]:
     """
     Execute multiple tool calls either in parallel or sequentially.
@@ -430,7 +430,7 @@ async def execute_tools_parallel(
     Returns:
         List of tool execution results in the same order as input tool_calls
     """
-    if not parallel_tool_calls:
+    if not enable_parallel:
         # Sequential execution (current behavior)
         results = []
         for tool_call in tool_calls:
@@ -505,4 +505,3 @@ def verify_post_tool_function(function: Callable):
         raise ValueError("post_tool_function must have parameter named `tool_result`")
 
     return function
-

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {
 setup(
     name="defog",
     packages=find_packages(),
-    version="1.2.4",
+    version="1.2.5",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/tests/test_llm_post_response_hook.py
+++ b/tests/test_llm_post_response_hook.py
@@ -108,6 +108,7 @@ async def test_post_response_hook_gemini():
     assert len(response_hook_calls) == 1
     assert "gemini hook test" in response.content.lower()
 
+
 @pytest.mark.asyncio
 @skip_if_no_api_key("anthropic")
 async def test_post_response_hook_anthropic():
@@ -128,7 +129,6 @@ async def test_post_response_hook_anthropic():
     # Verify hook was called
     assert len(response_hook_calls) == 1
     assert "anthropic hook test" in response.content.lower()
-
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -619,12 +619,12 @@ class TestParallelToolCalls(unittest.IsolatedAsyncioTestCase):
 
         # Test sequential batch execution
         results_sequential = await self.handler.execute_tool_calls_batch(
-            tool_calls, self.tool_dict, enable_parallel=False
+            tool_calls, self.tool_dict, parallel_tool_calls=False
         )
 
         # Test parallel batch execution
         results_parallel = await self.handler.execute_tool_calls_batch(
-            tool_calls, self.tool_dict, enable_parallel=True
+            tool_calls, self.tool_dict, parallel_tool_calls=True
         )
 
         # Results should be identical

--- a/tests/test_post_response_hook.py
+++ b/tests/test_post_response_hook.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Test for post_response_hook hook functionality."""
+
+import pytest
+import asyncio
+from typing import Any, Dict, List
+
+from defog.llm.utils import chat_async
+from tests.conftest import skip_if_no_api_key
+
+from dotenv import load_dotenv
+
+load_dotenv()
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+# Mock response hook for testing
+response_hook_calls = []
+
+
+async def mock_response_hook(
+    response: Any,
+    messages: List[Dict[str, Any]],
+) -> None:
+    """Mock hook that records calls."""
+    response_hook_calls.append(
+        {
+            "response_type": type(response).__name__,
+            "message_count": len(messages),
+        }
+    )
+
+    logging.info(response)
+
+
+def calculate(expression: str) -> str:
+    """Simple calculation tool for testing."""
+    try:
+        result = eval(expression, {"__builtins__": {}}, {})
+        return f"The result is {result}"
+    except:
+        return f"Error evaluating {expression}"
+
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("openai")
+async def test_post_response_hook_simple():
+    """Test the hook is called for simple chat completion."""
+    global response_hook_calls
+    response_hook_calls = []
+
+    response = await chat_async(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Say 'Hello, hooks!' and nothing else."}],
+        post_response_hook=mock_response_hook,
+        max_completion_tokens=50,
+    )
+
+    # Verify hook was called
+    assert len(response_hook_calls) == 1
+    assert response_hook_calls[0]["message_count"] == 1
+    assert "hooks" in response.content.lower()
+
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("openai")
+async def test_post_response_hook_with_tools():
+    """Test the hook is called multiple times during tool use."""
+    global response_hook_calls
+    response_hook_calls = []
+
+    response = await chat_async(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Calculate 25 * 4"}],
+        tools=[calculate],
+        post_response_hook=mock_response_hook,
+        max_completion_tokens=200,
+    )
+
+    # Verify hook was called multiple times (at least twice - initial + after tool)
+    assert len(response_hook_calls) >= 2
+    assert response.tool_outputs is not None
+    assert len(response.tool_outputs) > 0
+    assert "100" in response.content
+
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("gemini")
+async def test_post_response_hook_gemini():
+    """Test the hook works with gemini provider."""
+    global response_hook_calls
+    response_hook_calls = []
+
+    response = await chat_async(
+        provider="gemini",
+        model="gemini-2.5-flash-lite-preview-06-17",
+        messages=[
+            {"role": "user", "content": "Say 'gemini hook test' and nothing else."}
+        ],
+        post_response_hook=mock_response_hook,
+        max_completion_tokens=50,
+    )
+
+    # Verify hook was called
+    assert len(response_hook_calls) == 1
+    assert "gemini hook test" in response.content.lower()
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("anthropic")
+async def test_post_response_hook_anthropic():
+    """Test the hook works with anthropic provider."""
+    global response_hook_calls
+    response_hook_calls = []
+
+    response = await chat_async(
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        messages=[
+            {"role": "user", "content": "Say 'anthropic hook test' and nothing else."}
+        ],
+        post_response_hook=mock_response_hook,
+        max_completion_tokens=50,
+    )
+
+    # Verify hook was called
+    assert len(response_hook_calls) == 1
+    assert "anthropic hook test" in response.content.lower()
+
+
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("gemini")
+async def test_normal():
+    """Test our validation function."""
+    global response_hook_calls
+    response_hook_calls = []
+
+    def func():
+        pass
+
+    response = await chat_async(
+        provider="gemini",
+        model="gemini-2.5-flash-lite-preview-06-17",
+        messages=[
+            {"role": "user", "content": "Say 'gemini hook test' and nothing else."}
+        ],
+        max_completion_tokens=50,
+    )
+
+    # Verify hook was called
+    assert "gemini hook test" in response.content.lower()

--- a/tests/test_post_response_hook.py
+++ b/tests/test_post_response_hook.py
@@ -134,12 +134,9 @@ async def test_post_response_hook_anthropic():
 @pytest.mark.asyncio
 @skip_if_no_api_key("gemini")
 async def test_normal():
-    """Test our validation function."""
+    """Test normal api without the post response hook."""
     global response_hook_calls
     response_hook_calls = []
-
-    def func():
-        pass
 
     response = await chat_async(
         provider="gemini",
@@ -150,5 +147,5 @@ async def test_normal():
         max_completion_tokens=50,
     )
 
-    # Verify hook was called
+    # Verify this worked
     assert "gemini hook test" in response.content.lower()

--- a/tests/test_tool_output_validation.py
+++ b/tests/test_tool_output_validation.py
@@ -203,7 +203,7 @@ class TestToolHandler:
         ]
 
         results = await handler.execute_tool_calls_batch(
-            tool_calls=tool_calls, tool_dict=tool_dict, enable_parallel=True
+            tool_calls=tool_calls, tool_dict=tool_dict, parallel_tool_calls=True
         )
 
         assert len(results) == 3


### PR DESCRIPTION
This lets us track the responses as they come, in addition to the existing `post_tool_function`.

- Add optional post_response_hook callback to base provider interface
- Implement hook calls in oai, gemini and anthropic providers after each response
- Add tests for the new functionality

Usage:
```python
async def log_responses(
    response: Any,
    messages: List[Dict[str, Any]],
) -> None:
    logging.info(response)

def calculate(expression: str) -> str:
    """Simple calculation tool for testing."""
    try:
        result = eval(expression, {"__builtins__": {}}, {})
        return f"The result is {result}"
    except:
        return f"Error evaluating {expression}"

response = await chat_async(
        provider="openai",
        model="gpt-4o-mini",
        messages=[{"role": "user", "content": "Calculate 25 * 4"}],
        tools=[calculate],
        post_response_hook=log_responses,
        max_completion_tokens=200,
    )
```


Run tests with:
```
pytest ./tests/test_post_response_hook.py -vvv -o log_cli=true --log-cli-level=INFO
```