### PR TITLE
feat: Add configurable tool output cutoff size

### DIFF
--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -736,7 +736,7 @@ THE RESPONSE SHOULD START WITH '{{' AND END WITH '}}' WITH NO OTHER CHARACTERS B
 
         # Create a ToolHandler instance with tool_budget and image_result_keys if provided
         tool_handler = self.create_tool_handler_with_budget(
-            tool_budget, image_result_keys
+            tool_budget, image_result_keys, kwargs.get("tool_output_max_tokens")
         )
 
         if post_tool_function:

--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -258,11 +258,14 @@ class BaseLLMProvider(ABC):
         self,
         tool_budget: Optional[Dict[str, int]] = None,
         image_result_keys: Optional[List[str]] = None,
+        tool_output_max_tokens: Optional[int] = None,
     ) -> ToolHandler:
-        """Create a ToolHandler instance with optional tool budget and image result keys."""
-        if tool_budget or image_result_keys:
+        """Create a ToolHandler instance with optional tool budget, image result keys, and output token limit."""
+        if tool_budget or image_result_keys or tool_output_max_tokens is not None:
             return ToolHandler(
-                tool_budget=tool_budget, image_result_keys=image_result_keys
+                tool_budget=tool_budget,
+                image_result_keys=image_result_keys,
+                tool_output_max_tokens=tool_output_max_tokens,
             )
         return self.tool_handler
 

--- a/defog/llm/providers/deepseek_provider.py
+++ b/defog/llm/providers/deepseek_provider.py
@@ -415,7 +415,9 @@ Respond with JSON only.
         from openai import AsyncOpenAI
 
         # Create a ToolHandler instance with tool_budget if provided
-        tool_handler = self.create_tool_handler_with_budget(tool_budget)
+        tool_handler = self.create_tool_handler_with_budget(
+            tool_budget, None, kwargs.get("tool_output_max_tokens")
+        )
 
         if post_tool_function:
             tool_handler.validate_post_tool_function(post_tool_function)

--- a/defog/llm/providers/gemini_provider.py
+++ b/defog/llm/providers/gemini_provider.py
@@ -520,7 +520,7 @@ class GeminiProvider(BaseLLMProvider):
         """Execute a chat completion with Gemini."""
         # Create a ToolHandler instance with tool_budget and image_result_keys if provided
         tool_handler = self.create_tool_handler_with_budget(
-            tool_budget, image_result_keys
+            tool_budget, image_result_keys, kwargs.get("tool_output_max_tokens")
         )
 
         if post_tool_function:

--- a/defog/llm/providers/mistral_provider.py
+++ b/defog/llm/providers/mistral_provider.py
@@ -389,7 +389,9 @@ class MistralProvider(BaseLLMProvider):
         from mistralai import Mistral
 
         # Create a ToolHandler instance with tool_budget if provided
-        tool_handler = self.create_tool_handler_with_budget(tool_budget)
+        tool_handler = self.create_tool_handler_with_budget(
+            tool_budget, None, kwargs.get("tool_output_max_tokens")
+        )
 
         if post_tool_function:
             tool_handler.validate_post_tool_function(post_tool_function)

--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -504,7 +504,7 @@ class OpenAIProvider(BaseLLMProvider):
 
         # Create a ToolHandler instance with tool_budget and image_result_keys if provided
         tool_handler = self.create_tool_handler_with_budget(
-            tool_budget, image_result_keys
+            tool_budget, image_result_keys, kwargs.get("tool_output_max_tokens")
         )
 
         if post_tool_function:

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -113,6 +113,7 @@ async def chat_async(
     tool_budget: Optional[Dict[str, int]] = None,
     insert_tool_citations: bool = False,
     parallel_tool_calls: bool = False,
+    tool_output_max_tokens: int = 10000,
 ) -> LLMResponse:
     """
     Execute a chat completion with explicit provider parameter.
@@ -143,6 +144,7 @@ async def chat_async(
         tool_budget: Dictionary mapping tool names to maximum allowed calls. Tools not in the dictionary have unlimited calls.
         insert_tool_citations: If True, adds citations to the response using tool outputs as source documents (OpenAI and Anthropic only)
         parallel_tool_calls: Enable parallel tool calls when set to True (default: False)
+        tool_output_max_tokens: Maximum tokens allowed in tool outputs (default: 10000). Set to -1 to disable the check.
 
     Returns:
         LLMResponse object containing the result
@@ -229,6 +231,7 @@ async def chat_async(
                 image_result_keys=image_result_keys,
                 tool_budget=tool_budget,
                 parallel_tool_calls=parallel_tool_calls,
+                tool_output_max_tokens=tool_output_max_tokens,
             )
 
             # Process citations if requested and provider supports it

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -244,6 +244,7 @@ async def chat_async(
     tool_budget: Optional[Dict[str, int]] = None,
     insert_tool_citations: bool = False,
     parallel_tool_calls: bool = False,
+    tool_output_max_tokens: int = 10000,
 ) -> LLMResponse
 ```
 


### PR DESCRIPTION
## Summary
- Added `tool_output_max_tokens` parameter to `chat_async` to make tool output size limits configurable
- Default limit remains 10,000 tokens for backward compatibility
- Setting `tool_output_max_tokens=-1` disables the check entirely

## Usage

```python
from defog import chat_async

# Use default limit (10,000 tokens)
response = await chat_async(
    provider="openai",
    model="gpt-4",
    messages=[{"role": "user", "content": "Query the database"}],
    tools=[sql_query_tool]
)

# Set a custom limit for large SQL results
response = await chat_async(
    provider="openai",
    model="gpt-4",
    messages=[{"role": "user", "content": "Get all records from large table"}],
    tools=[sql_query_tool],
    tool_output_max_tokens=50000  # Allow up to 50k tokens for a tool output
)

# Disable the limit entirely for unlimited output
response = await chat_async(
    provider="openai",
    model="gpt-4",
    messages=[{"role": "user", "content": "Export full dataset"}],
    tools=[sql_query_tool],
    tool_output_max_tokens=-1  # No token limit on tool outputs
)
```

## Changes
- Added `tool_output_max_tokens` parameter to `chat_async` function with default value of 10,000
- Updated `ToolHandler` to accept and use the configurable limit
- Modified `BaseLLMProvider.create_tool_handler_with_budget` to pass through the parameter
- Updated all provider implementations (OpenAI, Anthropic, Gemini, Mistral, DeepSeek) to pass the parameter
- Updated API documentation
- Added comprehensive tests in `test_llm_tool_calls.py`

## Test plan
- [x] Added tests for default limit behavior
- [x] Added tests for custom limits
- [x] Added tests for disabled limit (tool_output_max_tokens=-1)
- [x] Tested with multiple providers (OpenAI, Anthropic)
- [x] All tests pass successfully